### PR TITLE
BREAKING CHANGE: Add periodic batching

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ kernel.Bind<IPostHogAnalytics>()
 
 ### Singleton Lifetime and Batching Semantics
 
-The `PostHogAnalytics` client is meant to be scoped as a singleton. There is batching implemented through the PeriodicBatching package. 
+The `PostHogAnalytics` client is meant to be scoped as a singleton. There is batching implemented through the [PeriodicBatching package](https://github.com/ThiagoBarradas/periodic-batching). 
 
 It will batch up to 500 events (max) and periodically flush them (every 5s default). Events will automatically be flushed when the PostHogAnalytics instance is disposed of but you can also manually call `Flush()` if you need to.
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Currently, you can use the `IPostHogAnalytics` interface and set up a basic anal
 
 - `publicApiKey` -- Your PostHog [_project_ API key](https://app.posthog.com/settings/project)
 - `host` -- _Optional_. An alternative host, like your reverse proxy or `https://eu.posthog.com` for EU cloud.
+- `batchConfig` -- _Optional_. Configuration for event batching.
 
 There are only a limited set of features supported:
 
@@ -35,6 +36,22 @@ kernel.Bind<IPostHogAnalytics>()
 The `PostHogAnalytics` client is meant to be scoped as a singleton. There is batching implemented through the [PeriodicBatching package](https://github.com/ThiagoBarradas/periodic-batching). 
 
 It will batch up to 500 events (max) and periodically flush them (every 5s default). Events will automatically be flushed when the PostHogAnalytics instance is disposed of but you can also manually call `Flush()` if you need to.
+
+**Customizing Batch Configuration**
+
+Pass a `PostHogEventBatchingConfiguration` to the `Create` method, like so:
+
+```c#
+PostHogAnalytics.Create(postHogApiKey, 
+  batchConfig: new PostHogEventBatchingConfiguration() {
+    BatchSizeLimit = 1000,
+    Period = TimeSpan.FromSeconds(10)
+})
+```
+
+> PostHog limits batches to 20MB, so the default 500 should be well under this limit. If you run into errors with events not being sent, you may need to adjust the `BatchSizeLimit` for your needs.
+
+**Important Notes**
 
 This means you should not set Super (or Person) Properties unless they apply across requests. 
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ There are only a limited set of features supported:
 - `Register`
 - `RegisterOnce`
 
-There is no batching or flushing mechanism (yet) and the API is synchronous.
+### Batching and Flushing
+
+There is batching implemented through the PeriodicBatching package. A single batcher will run for all requests, and will
+automatically be flushed when the PostHogAnalytics instance is disposed of.
 
 ## Setup Example
 

--- a/src/DotPostHog.Test/PostHogAnalyticsTest.cs
+++ b/src/DotPostHog.Test/PostHogAnalyticsTest.cs
@@ -29,6 +29,8 @@ namespace DotPostHog.Test
     {
       _instance.Capture("test");
 
+      Task.Delay(100).Wait();
+
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x =>
           x.GetPostHogEventsCaptureRequestAnyOf().Batch.Count == 1), 0, default), Times.Once);
@@ -42,6 +44,8 @@ namespace DotPostHog.Test
       _instance.Capture("test3");
       _instance.Capture("test4");
       _instance.Capture("test5");
+
+      Task.Delay(100).Wait();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x =>
@@ -58,6 +62,8 @@ namespace DotPostHog.Test
       _instance.Capture("test5");
       _instance.Flush();
 
+      Task.Delay(100).Wait();
+
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x =>
           x.GetPostHogEventsCaptureRequestAnyOf().Batch.Count == 5), 0, default), Times.Once);
@@ -73,6 +79,8 @@ namespace DotPostHog.Test
       _instance.Capture("test5");
       ((PostHogAnalytics)_instance).Dispose();
 
+      Task.Delay(100).Wait();
+
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x =>
           x.GetPostHogEventsCaptureRequestAnyOf().Batch.Count == 5), 0, default), Times.Once);
@@ -85,6 +93,8 @@ namespace DotPostHog.Test
       {
         {"prop1", "test"}
       });
+
+      Task.Delay(100).Wait();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x => (string)
@@ -100,6 +110,8 @@ namespace DotPostHog.Test
       });
       _instance.Capture("test");
 
+      Task.Delay(100).Wait();
+
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x => (string)
           x.GetPostHogEventsCaptureRequestAnyOf().Batch[0].Properties["super"] == "test"), 0, default), Times.Once);
@@ -113,6 +125,8 @@ namespace DotPostHog.Test
         {"super_once", "test"}
       });
       _instance.Capture("test");
+
+      Task.Delay(100).Wait();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x => (string)
@@ -136,6 +150,8 @@ namespace DotPostHog.Test
       });
       _instance.Capture("test");
 
+      Task.Delay(100).Wait();
+
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x => (string)
           x.GetPostHogEventsCaptureRequestAnyOf().Batch[0].Properties["super"] == "good"), 0, default), Times.Once);
@@ -153,6 +169,8 @@ namespace DotPostHog.Test
         {"super", "good"}
       });
 
+      Task.Delay(100).Wait();
+
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x => (string)
           x.GetPostHogEventsCaptureRequestAnyOf().Batch[0].Properties["super"] == "good"), 0, default), Times.Once);
@@ -162,6 +180,8 @@ namespace DotPostHog.Test
     public void ShouldBeAbleToIdentifyUser()
     {
       _instance.Identify("user1");
+
+      Task.Delay(100).Wait();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x =>
@@ -176,6 +196,8 @@ namespace DotPostHog.Test
         {"email", "test@user.com"}
       });
 
+      Task.Delay(100).Wait();
+
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x =>
           (string)((Dictionary<string, object>)x.GetPostHogEventsCaptureRequestAnyOf().Batch[0].Properties["$set"])["email"] == "test@user.com"), 0, default), Times.Once);
@@ -188,6 +210,8 @@ namespace DotPostHog.Test
       {
         {"initial_url", "/landing-page"}
       });
+
+      Task.Delay(100).Wait();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x =>
@@ -205,6 +229,8 @@ namespace DotPostHog.Test
       {
         {"initial_url", "/landing-page"}
       });
+
+      Task.Delay(100).Wait();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x =>
@@ -228,6 +254,8 @@ namespace DotPostHog.Test
 
       _instance.Identify("user1");
 
+      Task.Delay(100).Wait();
+
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x =>
           (string)((Dictionary<string, object>)x.GetPostHogEventsCaptureRequestAnyOf().Batch[0].Properties["$set"])["email"] == "test@user.com" &&
@@ -243,6 +271,8 @@ namespace DotPostHog.Test
       });
       _instance.Identify("user1");
 
+      Task.Delay(100).Wait();
+
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x =>
           (string)x.GetPostHogEventsCaptureRequestAnyOf().Batch[0].Properties["super"] == "test"), 0, default), Times.Once);
@@ -256,6 +286,8 @@ namespace DotPostHog.Test
         {"super", "test"}
       });
       _instance.Identify("user1");
+
+      Task.Delay(100).Wait();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x =>

--- a/src/DotPostHog.Test/PostHogAnalyticsTest.cs
+++ b/src/DotPostHog.Test/PostHogAnalyticsTest.cs
@@ -29,7 +29,7 @@ namespace DotPostHog.Test
     {
       _instance.Capture("test");
 
-      Task.Delay(100).Wait();
+      Task.Delay(10).Wait();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x =>
@@ -45,7 +45,7 @@ namespace DotPostHog.Test
       _instance.Capture("test4");
       _instance.Capture("test5");
 
-      Task.Delay(100).Wait();
+      Task.Delay(10).Wait();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x =>
@@ -62,7 +62,7 @@ namespace DotPostHog.Test
       _instance.Capture("test5");
       _instance.Flush();
 
-      Task.Delay(100).Wait();
+      Task.Delay(10).Wait();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x =>
@@ -79,7 +79,7 @@ namespace DotPostHog.Test
       _instance.Capture("test5");
       ((PostHogAnalytics)_instance).Dispose();
 
-      Task.Delay(100).Wait();
+      Task.Delay(10).Wait();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x =>
@@ -94,7 +94,7 @@ namespace DotPostHog.Test
         {"prop1", "test"}
       });
 
-      Task.Delay(100).Wait();
+      Task.Delay(10).Wait();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x => (string)
@@ -110,7 +110,7 @@ namespace DotPostHog.Test
       });
       _instance.Capture("test");
 
-      Task.Delay(100).Wait();
+      Task.Delay(10).Wait();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x => (string)
@@ -126,7 +126,7 @@ namespace DotPostHog.Test
       });
       _instance.Capture("test");
 
-      Task.Delay(100).Wait();
+      Task.Delay(10).Wait();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x => (string)
@@ -150,7 +150,7 @@ namespace DotPostHog.Test
       });
       _instance.Capture("test");
 
-      Task.Delay(100).Wait();
+      Task.Delay(10).Wait();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x => (string)
@@ -169,7 +169,7 @@ namespace DotPostHog.Test
         {"super", "good"}
       });
 
-      Task.Delay(100).Wait();
+      Task.Delay(10).Wait();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x => (string)
@@ -181,7 +181,7 @@ namespace DotPostHog.Test
     {
       _instance.Identify("user1");
 
-      Task.Delay(100).Wait();
+      Task.Delay(10).Wait();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x =>
@@ -196,7 +196,7 @@ namespace DotPostHog.Test
         {"email", "test@user.com"}
       });
 
-      Task.Delay(100).Wait();
+      Task.Delay(10).Wait();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x =>
@@ -211,7 +211,7 @@ namespace DotPostHog.Test
         {"initial_url", "/landing-page"}
       });
 
-      Task.Delay(100).Wait();
+      Task.Delay(10).Wait();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x =>
@@ -230,7 +230,7 @@ namespace DotPostHog.Test
         {"initial_url", "/landing-page"}
       });
 
-      Task.Delay(100).Wait();
+      Task.Delay(10).Wait();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x =>
@@ -254,7 +254,7 @@ namespace DotPostHog.Test
 
       _instance.Identify("user1");
 
-      Task.Delay(100).Wait();
+      Task.Delay(10).Wait();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x =>
@@ -271,7 +271,7 @@ namespace DotPostHog.Test
       });
       _instance.Identify("user1");
 
-      Task.Delay(100).Wait();
+      Task.Delay(10).Wait();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x =>
@@ -287,7 +287,7 @@ namespace DotPostHog.Test
       });
       _instance.Identify("user1");
 
-      Task.Delay(100).Wait();
+      Task.Delay(10).Wait();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x =>

--- a/src/DotPostHog.Test/PostHogAnalyticsTest.cs
+++ b/src/DotPostHog.Test/PostHogAnalyticsTest.cs
@@ -35,6 +35,20 @@ namespace DotPostHog.Test
     }
 
     [Fact]
+    public void ShouldBeAbleToCaptureABatchOfEvents()
+    {
+      _instance.Capture("test1");
+      _instance.Capture("test2");
+      _instance.Capture("test3");
+      _instance.Capture("test4");
+      _instance.Capture("test5");
+
+      _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
+        It.Is<PostHogEventsCaptureRequest>(x =>
+          x.GetPostHogEventsCaptureRequestAnyOf().Batch.Count == 5), 0, default), Times.Once);
+    }
+
+    [Fact]
     public void ShouldBeAbleToCaptureEventWithProperties()
     {
       _instance.Capture("test", new PostHogEventProperties()

--- a/src/DotPostHog.Test/PostHogAnalyticsTest.cs
+++ b/src/DotPostHog.Test/PostHogAnalyticsTest.cs
@@ -48,7 +48,7 @@ namespace DotPostHog.Test
           x.GetPostHogEventsCaptureRequestAnyOf().Batch.Count == 5), 0, default), Times.Once);
     }
 
-        [Fact]
+    [Fact]
     public void ShouldBeAbleToFlushABatchOfEvents()
     {
       _instance.Capture("test1");
@@ -57,6 +57,21 @@ namespace DotPostHog.Test
       _instance.Capture("test4");
       _instance.Capture("test5");
       _instance.Flush();
+
+      _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
+        It.Is<PostHogEventsCaptureRequest>(x =>
+          x.GetPostHogEventsCaptureRequestAnyOf().Batch.Count == 5), 0, default), Times.Once);
+    }
+
+    [Fact]
+    public void ShouldFlushBatchWhenDisposed()
+    {
+      _instance.Capture("test1");
+      _instance.Capture("test2");
+      _instance.Capture("test3");
+      _instance.Capture("test4");
+      _instance.Capture("test5");
+      ((PostHogAnalytics)_instance).Dispose();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x =>

--- a/src/DotPostHog.Test/PostHogAnalyticsTest.cs
+++ b/src/DotPostHog.Test/PostHogAnalyticsTest.cs
@@ -48,6 +48,21 @@ namespace DotPostHog.Test
           x.GetPostHogEventsCaptureRequestAnyOf().Batch.Count == 5), 0, default), Times.Once);
     }
 
+        [Fact]
+    public void ShouldBeAbleToFlushABatchOfEvents()
+    {
+      _instance.Capture("test1");
+      _instance.Capture("test2");
+      _instance.Capture("test3");
+      _instance.Capture("test4");
+      _instance.Capture("test5");
+      _instance.Flush();
+
+      _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
+        It.Is<PostHogEventsCaptureRequest>(x =>
+          x.GetPostHogEventsCaptureRequestAnyOf().Batch.Count == 5), 0, default), Times.Once);
+    }
+
     [Fact]
     public void ShouldBeAbleToCaptureEventWithProperties()
     {

--- a/src/DotPostHog.Test/PostHogAnalyticsTest.cs
+++ b/src/DotPostHog.Test/PostHogAnalyticsTest.cs
@@ -29,7 +29,7 @@ namespace DotPostHog.Test
     {
       _instance.Capture("test");
 
-      Task.Delay(10).Wait();
+      DangerouslyWaitForInitialFlush();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x =>
@@ -45,7 +45,7 @@ namespace DotPostHog.Test
       _instance.Capture("test4");
       _instance.Capture("test5");
 
-      Task.Delay(10).Wait();
+      DangerouslyWaitForInitialFlush();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x =>
@@ -62,7 +62,7 @@ namespace DotPostHog.Test
       _instance.Capture("test5");
       _instance.Flush();
 
-      Task.Delay(10).Wait();
+      DangerouslyWaitForInitialFlush();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x =>
@@ -79,7 +79,7 @@ namespace DotPostHog.Test
       _instance.Capture("test5");
       ((PostHogAnalytics)_instance).Dispose();
 
-      Task.Delay(10).Wait();
+      DangerouslyWaitForInitialFlush();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x =>
@@ -94,7 +94,7 @@ namespace DotPostHog.Test
         {"prop1", "test"}
       });
 
-      Task.Delay(10).Wait();
+      DangerouslyWaitForInitialFlush();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x => (string)
@@ -110,7 +110,7 @@ namespace DotPostHog.Test
       });
       _instance.Capture("test");
 
-      Task.Delay(10).Wait();
+      DangerouslyWaitForInitialFlush();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x => (string)
@@ -126,7 +126,7 @@ namespace DotPostHog.Test
       });
       _instance.Capture("test");
 
-      Task.Delay(10).Wait();
+      DangerouslyWaitForInitialFlush();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x => (string)
@@ -150,7 +150,7 @@ namespace DotPostHog.Test
       });
       _instance.Capture("test");
 
-      Task.Delay(10).Wait();
+      DangerouslyWaitForInitialFlush();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x => (string)
@@ -169,7 +169,7 @@ namespace DotPostHog.Test
         {"super", "good"}
       });
 
-      Task.Delay(10).Wait();
+      DangerouslyWaitForInitialFlush();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x => (string)
@@ -181,7 +181,7 @@ namespace DotPostHog.Test
     {
       _instance.Identify("user1");
 
-      Task.Delay(10).Wait();
+      DangerouslyWaitForInitialFlush();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x =>
@@ -196,7 +196,7 @@ namespace DotPostHog.Test
         {"email", "test@user.com"}
       });
 
-      Task.Delay(10).Wait();
+      DangerouslyWaitForInitialFlush();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x =>
@@ -211,7 +211,7 @@ namespace DotPostHog.Test
         {"initial_url", "/landing-page"}
       });
 
-      Task.Delay(10).Wait();
+      DangerouslyWaitForInitialFlush();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x =>
@@ -230,7 +230,7 @@ namespace DotPostHog.Test
         {"initial_url", "/landing-page"}
       });
 
-      Task.Delay(10).Wait();
+      DangerouslyWaitForInitialFlush();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x =>
@@ -254,7 +254,7 @@ namespace DotPostHog.Test
 
       _instance.Identify("user1");
 
-      Task.Delay(10).Wait();
+      DangerouslyWaitForInitialFlush();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x =>
@@ -271,7 +271,7 @@ namespace DotPostHog.Test
       });
       _instance.Identify("user1");
 
-      Task.Delay(10).Wait();
+      DangerouslyWaitForInitialFlush();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x =>
@@ -287,12 +287,19 @@ namespace DotPostHog.Test
       });
       _instance.Identify("user1");
 
-      Task.Delay(10).Wait();
+      DangerouslyWaitForInitialFlush();
 
       _mockCaptureApi.Verify(x => x.CaptureSendBatchAsync(null, null,
         It.Is<PostHogEventsCaptureRequest>(x =>
           (string)x.GetPostHogEventsCaptureRequestAnyOf().Batch[0].Properties["super"] == "test"), 0, default), Times.Once);
     }
 
+    /// <summary>
+    /// Due to the internal implementation of Periodic Batching, we need to wait for the initial flush to complete
+    /// but there's no easy way to do this without exposing internal state. This is a hack to wait for the initial flush.
+    /// </summary>
+    private void DangerouslyWaitForInitialFlush() {
+      Task.Delay(25).Wait();
+    }
   }
 }

--- a/src/DotPostHog/DotPostHog.csproj
+++ b/src/DotPostHog/DotPostHog.csproj
@@ -30,6 +30,7 @@
   <ItemGroup>
     <PackageReference Include="JsonSubTypes" Version="2.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="PeriodicBatching" Version="1.1.0" />
     <PackageReference Include="RestSharp" Version="110.2.0" />
     <PackageReference Include="Polly" Version="8.2.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/src/DotPostHog/PostHogAnalytics.cs
+++ b/src/DotPostHog/PostHogAnalytics.cs
@@ -1,7 +1,14 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using DotPostHog.Api;
 using DotPostHog.Model;
+using PeriodicBatching;
+using PeriodicBatching.Interfaces;
+using PeriodicBatching.Models;
 
 namespace DotPostHog
 {
@@ -20,7 +27,7 @@ namespace DotPostHog
     /// Identifies a user in PostHog
     /// </summary>
     /// <returns></returns>
-    PostHogEventsCaptureResponse Identify(string distinctId, IDictionary<string, object> sysSet = null, IDictionary<string, object> sysSetOnce = null);
+    void Identify(string distinctId, IDictionary<string, object> sysSet = null, IDictionary<string, object> sysSetOnce = null);
 
     /// <summary>
     /// Aliases a user in PostHog. Alias ID should not match any existing distinct ID.
@@ -28,13 +35,19 @@ namespace DotPostHog
     /// <param name="distinctId">New distinct ID</param>
     /// <param name="aliasId">Old distinct ID</param>
     /// <returns></returns>
-    PostHogEventsCaptureResponse Alias(string distinctId, string aliasId);
+    void Alias(string distinctId, string aliasId);
 
     /// <summary>
     /// Captures an event in PostHog
     /// </summary>
     /// <returns></returns>
-    PostHogEventsCaptureResponse Capture(string eventName, PostHogEventProperties properties = null);
+    void Capture(string eventName, PostHogEventProperties properties = null);
+
+    /// <summary>
+    /// Immediately flushes the event queue to PostHog. This is automatically called when the instance is disposed.
+    /// </summary>
+    /// <returns></returns>
+    void Flush();
 
     /// <summary>
     /// Sets a user's properties as its own event
@@ -61,71 +74,128 @@ namespace DotPostHog
     void Unregister(string property);
   }
 
-  public interface IPostHogRequestContext
+  public class BatchingCaptureAdapter : IDisposable
   {
-    string Ip { get; }
+    private static IPeriodicBatching<PostHogEvent> _batcher;
+    private readonly string _publicApiKey;
+    private readonly ICaptureApi _captureApi;
+
+    public BatchingCaptureAdapter(string publicApiKey, ICaptureApi captureApi)
+    {
+      _publicApiKey = publicApiKey;
+      _captureApi = captureApi;
+
+      var batchingConfig = new PeriodicBatchingConfiguration<PostHogEvent>
+      {
+        // PostHog limits batch content length to 20MB,
+        // and we don't exactly know how big that will be based on 
+        // number of events
+        BatchSizeLimit = 500,
+        BatchingFunc = PostEventBatch
+      };
+      _batcher = new PeriodicBatching<PostHogEvent>(batchingConfig);
+    }
+
+    private async Task PostEventBatch(List<PostHogEvent> events)
+    {
+      if (events.Count <= 0)
+      {
+        return;
+      }
+
+      var body = new PostHogEventsCaptureRequest(
+        new PostHogEventsCaptureRequestAnyOf(_publicApiKey, events.ToList()));
+
+      await _captureApi.CaptureSendBatchAsync(null, null, body);
+    }
+
+    public void Enqueue(PostHogEvent body)
+    {
+      _batcher.Add(body);
+    }
+
+    public void Flush()
+    {
+      _batcher.Flush();
+    }
+
+    bool _disposed;
+
+    public void Dispose()
+    {
+      Dispose(true);
+      GC.SuppressFinalize(this);
+    }
+
+    ~BatchingCaptureAdapter()
+    {
+      Dispose(false);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+      if (_disposed)
+        return;
+
+      if (disposing)
+      {
+        _batcher.Dispose();
+      }
+
+      _disposed = true;
+    }
   }
 
-  public class PostHogAnalytics : IPostHogAnalytics
+  public class PostHogAnalytics : IPostHogAnalytics, IDisposable
   {
     private readonly Dictionary<string, object> _superProperties;
     private readonly Dictionary<string, object> _superPropertiesOnce;
     private readonly Dictionary<string, object> _personSysSetProperties;
     private readonly Dictionary<string, object> _personSysSetPropertiesOnce;
-    private readonly string _publicApiKey;
-    private readonly ICaptureApi _captureApi;
-    private readonly IPostHogRequestContext _requestContext;
+    private readonly BatchingCaptureAdapter _batcher;
 
     /// <summary>
     /// Creates a new instance of PostHogAnalytics
     /// </summary>
     /// <param name="publicApiKey">Your PostHog public API key</param>
-    /// <param name="requestContext">An implementation of IPostHogRequestContext that provides access to request properties</param> 
     /// <param name="host">The PostHog host to send events to. Defaults to https://app.posthog.com</param>
-    public static IPostHogAnalytics Create(string publicApiKey, IPostHogRequestContext requestContext, string host = "https://app.posthog.com")
+    public static IPostHogAnalytics Create(string publicApiKey, string host = "https://app.posthog.com")
     {
       var config = new Client.Configuration()
       {
-        BasePath = host,
-        DefaultHeaders = new Dictionary<string, string>() {
-          {"HTTP_X_FORWARDED_FOR", requestContext.Ip}
-        }
+        BasePath = host
       };
 
-      return new PostHogAnalytics(publicApiKey, new CaptureApi(config), requestContext);
+      return new PostHogAnalytics(publicApiKey, new CaptureApi(config));
     }
 
     /// <summary>
     /// Bring your own implementation of ICaptureApi. Used mainly for testing.
     /// </summary>
     /// <param name="publicApiKey"></param>
-    /// <param name="requestContext"></param>
     /// <param name="customCaptureApi"></param>
     /// <returns></returns>
-    public static IPostHogAnalytics CreateCustom(string publicApiKey, IPostHogRequestContext requestContext, ICaptureApi customCaptureApi)
+    public static IPostHogAnalytics CreateCustom(string publicApiKey, ICaptureApi customCaptureApi)
     {
-      return new PostHogAnalytics(publicApiKey, customCaptureApi, requestContext);
+      return new PostHogAnalytics(publicApiKey, customCaptureApi);
     }
 
-    private PostHogAnalytics(string publicApiKey, ICaptureApi captureApi, IPostHogRequestContext requestContext)
+    private PostHogAnalytics(string publicApiKey, ICaptureApi captureApi)
     {
-      _publicApiKey = publicApiKey;
-      _requestContext = requestContext;
-      _captureApi = captureApi;
+      _batcher = new BatchingCaptureAdapter(publicApiKey, captureApi);
 
       _superProperties = new Dictionary<string, object>() {
         { "$lib", "DotPostHog" },
         { "$lib_version", GetAssemblyVersion() },
-        { "$ip", _requestContext.Ip }
+        { "$geoip_disable", true } // Otherwise it will grab the server IP. This matches Node.js SDK behavior.
       };
       _superPropertiesOnce = new Dictionary<string, object>();
       _personSysSetProperties = new Dictionary<string, object>();
       _personSysSetPropertiesOnce = new Dictionary<string, object>();
     }
 
-    public PostHogEventsCaptureResponse Capture(string eventName, PostHogEventProperties properties = null)
+    public void Capture(string eventName, PostHogEventProperties properties = null)
     {
-      var ip = _requestContext.Ip;
       var props = MergeSuperProperties(properties);
       var userProps = MergeUserProperties(null, null);
 
@@ -134,15 +204,13 @@ namespace DotPostHog
       var body = new PostHogEvent()
       {
         VarEvent = eventName,
-        ApiKey = _publicApiKey,
         Properties = props
       };
-      return _captureApi.CaptureSend(ip, null, body);
+      _batcher.Enqueue(body);
     }
 
-    public PostHogEventsCaptureResponse Identify(string distinctId, IDictionary<string, object> sysSet = null, IDictionary<string, object> sysSetOnce = null)
+    public void Identify(string distinctId, IDictionary<string, object> sysSet = null, IDictionary<string, object> sysSetOnce = null)
     {
-      var ip = _requestContext.Ip;
       var props = MergeSuperProperties(null);
       var userProps = MergeUserProperties(sysSet, sysSetOnce);
 
@@ -156,26 +224,55 @@ namespace DotPostHog
       var body = new PostHogEvent()
       {
         VarEvent = "$identify",
-        ApiKey = _publicApiKey,
         DistinctId = distinctId,
         Properties = props
       };
-      return _captureApi.CaptureSend(ip, null, body);
+      _batcher.Enqueue(body);
     }
 
-    public PostHogEventsCaptureResponse Alias(string distinctId, string aliasId)
+    public void Alias(string distinctId, string aliasId)
     {
-      var ip = _requestContext.Ip;
       var body = new PostHogEvent()
       {
         VarEvent = "$create_alias",
-        ApiKey = _publicApiKey,
         DistinctId = distinctId,
         Properties = new PostHogEventProperties() {
           { "alias", aliasId }
         }
       };
-      return _captureApi.CaptureSend(ip, null, body);
+      _batcher.Enqueue(body);
+    }
+
+    public void Flush()
+    {
+      _batcher.Flush();
+    }
+
+    private bool _disposed = false;
+
+    public void Dispose()
+    {
+      Dispose(true);
+      GC.SuppressFinalize(this);
+    }
+
+    ~PostHogAnalytics()
+    {
+      Dispose(false);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+      if (_disposed)
+        return;
+
+      if (disposing)
+      {
+        // This will close and flush the batcher
+        _batcher.Dispose();
+      }
+
+      _disposed = true;
     }
 
     public void Register(IDictionary<string, object> properties)


### PR DESCRIPTION
This is meant to improve performance and remove sync calls to the API when called multiple times. This also ends up reusing the HttpClient (better). However, it removes the ability to add per-request semantics. Technically, you could use per-request scope but this would create multiple periodic batcher background tasks.

There could be a possibility to implement per-request batching semantics, so that any events queued during a request are flushed at the end (asynchronously, so they don't affect request timing) but this would lead to (many) more API calls for high-traffic apps.

## BREAKING CHANGE

- Remove request context
- Add periodic batching using `/batch` endpoint
- Disable GeoIP

## Changes

- Add [PeriodicBatching](https://github.com/ThiagoBarradas/periodic-batching) dependency
- Add `Flush()` method to interface to flush events
- Configure batching for 500 events with default 5s flush interval
  - _Note:_ PostHog doesn't limit the _number_ of events in a batch, just the request size to 20MB but without inspecting the full content payload, it's hard to guestimate how many events to limit the batch to. 500 seems OK but maybe this will need to be adjusted.

## Todo

- [x] Expose batching configuration for user (and test) tweaking

## Future

- [ ] Add `ILogger` support for logging request errors / failures / drops

## Notes

This isn't really ideal. The Optimizely SDK has a more robust [batch event processor](https://github.com/optimizely/csharp-sdk/blob/master/OptimizelySDK/Event/BatchEventProcessor.cs) implementation with a convenient builder API. It would be nice to extract this into its own library for reuse.